### PR TITLE
Freeze tornado version to avoid upgrading python2 version

### DIFF
--- a/build/docker/ubuntu/Dockerfile
+++ b/build/docker/ubuntu/Dockerfile
@@ -165,7 +165,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN gem install bundler --no-ri --no-rdoc
 
 # Python optional dependencies
-RUN pip2 install -U ipaddress backports.ssl_match_hostname tornado
+RUN pip2 install -U ipaddress backports.ssl_match_hostname tornado==4.5.3
 RUN pip3 install -U backports.ssl_match_hostname tornado
 
 # Go


### PR DESCRIPTION
Since tornado 5.0.0, it requires Python 2.7.9+ to install, however ubuntu trusty only provides libpython2.7.6 for now.

Stacktrace:
```
Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-XJGdhY/tornado/setup.py", line 146, in <module>
        raise ImportError("Tornado requires an up-to-date SSL module. This means "
    ImportError: Tornado requires an up-to-date SSL module. This means Python 2.7.9+ or 3.4+ (although some distributions have backported the necessary changes to older versions).
```