### PR TITLE
Fix apache-thrift binary bug

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -1442,7 +1442,7 @@ void t_go_generator::generate_countsetfields_helper(ofstream& out,
 
     t_type* type = (*f_iter)->get_type()->get_true_type();
 
-    if (!(is_pointer_field(*f_iter) || type->is_map() || type->is_set() || type->is_list()))
+    if (!(is_pointer_field(*f_iter) || type->is_map() || type->is_set() || type->is_list() || (type->is_binary() && !(*f_iter)->get_value()) ))
       continue;
 
     const string field_name(publicize(escape_string((*f_iter)->get_name())));


### PR DESCRIPTION
This PR fixes apache-thrift binary bug. The bug is caused by go generator; Because of the bug, the binary field inside a union struct will not be counted even if it has been set. 
Sample thrift:
![sample_test](https://user-images.githubusercontent.com/9288544/40144554-e7a707f4-5913-11e8-8294-a0af9fa499f2.png)
Buggy-generated Go code:
![wrong_result](https://user-images.githubusercontent.com/9288544/40144563-f09de940-5913-11e8-8473-2cb0addd07b3.png)
After fix:
![after-fix](https://user-images.githubusercontent.com/9288544/40144567-f4fa7a3a-5913-11e8-8b2d-9a31e20fb4c7.png)
